### PR TITLE
Use EABase defines over raw platform checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ add_library(EAThread ${EATHREAD_SOURCES})
 
 if(EATHREAD_BUILD_TESTS)
     add_subdirectory(test)
+else()
+    add_subdirectory(test/packages/EABase)
 endif()
 
 #-------------------------------------------------------------------------------------------

--- a/include/eathread/eathread.h
+++ b/include/eathread/eathread.h
@@ -740,9 +740,9 @@ namespace EA
 	#define EAThreadGetUniqueId(dest) dest = (EA::Thread::ThreadUniqueId)(uintptr_t)__readfsdword(0x18)
 
 #elif defined(EA_COMPILER_MSVC) && defined(EA_PROCESSOR_X86_64)
-	#pragma warning(push, 0)
+	EA_DISABLE_ALL_VC_WARNINGS()
 	#include <intrin.h>
-	#pragma warning(pop)
+	EA_RESTORE_ALL_VC_WARNINGS()
 	#define EAThreadGetUniqueId(dest) dest = (EA::Thread::ThreadUniqueId)(uintptr_t)__readgsqword(0x30)
 	// Could also use dest = (EA::Thread::ThreadUniqueId)NtCurrentTeb(), but that would require #including <windows.h>, which is very heavy.
 

--- a/include/eathread/eathread.h
+++ b/include/eathread/eathread.h
@@ -100,7 +100,7 @@
 	EA_RESTORE_VC_WARNING()
 #elif defined(EA_PLATFORM_UNIX) || EA_POSIX_THREADS_AVAILABLE
 	#include <pthread.h>
-	#if defined(_YVALS)         // Dinkumware doesn't usually provide gettimeofday or <sys/types.h>
+	#if defined(EA_HAVE_DINKUMWARE_CPP_LIBRARY)         // Dinkumware doesn't usually provide gettimeofday or <sys/types.h>
 		#include <time.h>       // clock_gettime
 	#elif defined(EA_PLATFORM_UNIX)
 		#include <sys/time.h>   // gettimeofday
@@ -728,7 +728,7 @@ namespace EA
 #if EA_USE_CPP11_CONCURRENCY
 	#define EAThreadGetUniqueId(dest) (dest = static_cast<uintptr_t>(std::hash<std::thread::id>()(std::this_thread::get_id())))
 
-#elif defined(EA_PLATFORM_WINDOWS) && defined(_MSC_VER) && !defined(_WIN64)
+#elif defined(EA_PLATFORM_WINDOWS) && defined(EA_COMPILER_MSVC) && !defined(EA_PLATFORM_WIN64)
 
 	// Reference implementation:
 	//extern "C" __declspec(dllimport) unsigned long __stdcall GetCurrentThreadId();
@@ -739,7 +739,7 @@ namespace EA
 	#pragma intrinsic(__readfsdword)
 	#define EAThreadGetUniqueId(dest) dest = (EA::Thread::ThreadUniqueId)(uintptr_t)__readfsdword(0x18)
 
-#elif defined(_MSC_VER) && defined(EA_PROCESSOR_X86_64)
+#elif defined(EA_COMPILER_MSVC) && defined(EA_PROCESSOR_X86_64)
 	#pragma warning(push, 0)
 	#include <intrin.h>
 	#pragma warning(pop)

--- a/include/eathread/eathread_atomic.h
+++ b/include/eathread/eathread_atomic.h
@@ -414,7 +414,7 @@ namespace EA
 		#endif
 
 
-		#ifdef _MSC_VER                  // VC++ yields spurious warnings about void* being cast to an integer type and vice-versa.
+		#ifdef EA_COMPILER_MSVC              // VC++ yields spurious warnings about void* being cast to an integer type and vice-versa.
 			#pragma warning(push)        // These warnings are baseless because we check for platform pointer size above.
 			#pragma warning(disable: 4311 4312 4251)
 		#endif
@@ -455,7 +455,7 @@ namespace EA
 		};
 
 
-		#ifdef _MSC_VER
+		#ifdef EA_COMPILER_MSVC
 			#pragma warning(pop)
 		#endif
 

--- a/include/eathread/eathread_atomic.h
+++ b/include/eathread/eathread_atomic.h
@@ -414,10 +414,9 @@ namespace EA
 		#endif
 
 
-		#ifdef EA_COMPILER_MSVC              // VC++ yields spurious warnings about void* being cast to an integer type and vice-versa.
-			#pragma warning(push)        // These warnings are baseless because we check for platform pointer size above.
-			#pragma warning(disable: 4311 4312 4251)
-		#endif
+		// VC++ yields spurious warnings about void* being cast to an integer type and vice-versa.
+		// These warnings are baseless because we check for platform pointer size above.
+		EA_DISABLE_VC_WARNING(4311 4312 4251)
 
 
 		/// class AtomicPointer
@@ -455,9 +454,7 @@ namespace EA
 		};
 
 
-		#ifdef EA_COMPILER_MSVC
-			#pragma warning(pop)
-		#endif
+		EA_RESTORE_VC_WARNING()
 
 	} // namespace Thread
 

--- a/include/eathread/eathread_barrier.h
+++ b/include/eathread/eathread_barrier.h
@@ -24,8 +24,7 @@
 	// These templates cannot be instantiated outside of the DLL. If you try, a
 	// link error will result. This compiler warning is intended to notify users
 	// of this.
-	#pragma warning(push)
-	#pragma warning(disable: 4251)
+	EA_DISABLE_VC_WARNING(4251)
 #endif
 
 #if defined(EA_PRAGMA_ONCE_SUPPORTED)
@@ -228,8 +227,8 @@ namespace EA
 
 
 #if defined(EA_DLL) && defined(EA_COMPILER_MSVC)
-   // re-enable warning(s) disabled above.
-   #pragma warning(pop)
+	// re-enable warning(s) disabled above.
+	EA_RESTORE_VC_WARNING()
 #endif
 
 

--- a/include/eathread/eathread_barrier.h
+++ b/include/eathread/eathread_barrier.h
@@ -17,7 +17,7 @@
 #include <eathread/eathread.h>
 
 
-#if defined(EA_DLL) && defined(_MSC_VER)
+#if defined(EA_DLL) && defined(EA_COMPILER_MSVC)
 	// Suppress warning about class 'AtomicInt32' needs to have a
 	// dll-interface to be used by clients of class which have a templated member.
 	// 
@@ -227,7 +227,7 @@ namespace EA
 } // namespace EA
 
 
-#if defined(EA_DLL) && defined(_MSC_VER)
+#if defined(EA_DLL) && defined(EA_COMPILER_MSVC)
    // re-enable warning(s) disabled above.
    #pragma warning(pop)
 #endif

--- a/include/eathread/eathread_callstack.h
+++ b/include/eathread/eathread_callstack.h
@@ -182,7 +182,7 @@ namespace EA
 		///    void* pInstruction;
 		///    EAGetInstructionPointer(pInstruction);
 		///
-		#if defined(_MSC_VER) && defined(EA_PROCESSOR_X86)
+		#if defined(EA_COMPILER_MSVC) && defined(EA_PROCESSOR_X86)
 			// We implement this via calling the next line of code as a function.
 			// Then we continue as if we were exiting that function but with no
 			// return statement. The result is that the instruction pointer will
@@ -204,13 +204,13 @@ namespace EA
 				{EAGetInstructionPointer(p);}
 			EA_RESTORE_VC_WARNING()
 
-		#elif defined(_MSC_VER) && (defined(EA_PROCESSOR_X86_64) || defined(EA_PROCESSOR_ARM))
+		#elif defined(EA_COMPILER_MSVC) && (defined(EA_PROCESSOR_X86_64) || defined(EA_PROCESSOR_ARM))
 
 			EATHREADLIB_API EA_NO_INLINE void GetInstructionPointer(void*& p);
 
 			#define EAGetInstructionPointer(p) EA::Thread::GetInstructionPointer(p)
 
-		#elif defined(__ARMCC_VERSION) // ARM compiler
+		#elif defined(EA_COMPILER_ARM) // ARM compiler
 
 			// Even if there are compiler intrinsics that let you get the instruction pointer, 
 			// this function can still be useful. For example, on ARM platforms this function
@@ -226,7 +226,7 @@ namespace EA
 		//    // To do: implement this directly instead of via a call to GetInstructionPointer.
 		//    #define EAGetInstructionPointer(p) EA::Thread::GetInstructionPointer(p)
 			
-		#elif defined(__GNUC__) || defined(EA_COMPILER_CLANG) // This covers EA_PLATFORM_UNIX, EA_PLATFORM_OSX 
+		#elif defined(EA_COMPILER_GNUC) || defined(EA_COMPILER_CLANG) // This covers EA_PLATFORM_UNIX, EA_PLATFORM_OSX
 
 			// Even if there are compiler intrinsics that let you get the instruction pointer, 
 			// this function can still be useful. For example, on ARM platforms this function
@@ -289,7 +289,7 @@ namespace EA
 		EATHREADLIB_API void* GetStackLimit();
 
 
-		#if defined(_MSC_VER) && defined(EA_PROCESSOR_X86)
+		#if defined(EA_COMPILER_MSVC) && defined(EA_PROCESSOR_X86)
 			#define EASetStackBase()               \
 			{                                      \
 				void* esp;                         \
@@ -297,19 +297,19 @@ namespace EA
 				::EA::Thread::SetStackBase(esp);   \
 			}                               
 
-		#elif defined(_MSC_VER) && (defined(EA_PROCESSOR_X86_64) || defined(EA_PROCESSOR_ARM))
+		#elif defined(EA_COMPILER_MSVC) && (defined(EA_PROCESSOR_X86_64) || defined(EA_PROCESSOR_ARM))
 			// This implementation uses SetStackBase(NULL), which internally retrieves the stack pointer.
 			#define EASetStackBase()                     \
 			{                                            \
 				::EA::Thread::SetStackBase((void*)NULL); \
 			}                                            \
 
-		#elif defined(__ARMCC_VERSION)          // ARM compiler
+		#elif defined(EA_COMPILER_ARM)          // ARM compiler
 
 			#define EASetStackBase()  \
 				::EA::Thread::SetStackBase((void*)__current_sp())
 
-		#elif defined(__GNUC__) // This covers EA_PLATFORM_UNIX, EA_PLATFORM_OSX
+		#elif defined(EA_COMPILER_GNUC) // This covers EA_PLATFORM_UNIX, EA_PLATFORM_OSX
 
 			#define EASetStackBase()  \
 				::EA::Thread::SetStackBase((void*)__builtin_frame_address(0));

--- a/include/eathread/eathread_condition.h
+++ b/include/eathread/eathread_condition.h
@@ -29,8 +29,7 @@
 	// These templates cannot be instantiated outside of the DLL. If you try, a
 	// link error will result. This compiler warning is intended to notify users
 	// of this.
-	#pragma warning(push)
-	#pragma warning(disable: 4251)
+	EA_DISABLE_VC_WARNING(4251)
 #endif
 
 #if defined(EA_PRAGMA_ONCE_SUPPORTED)
@@ -236,19 +235,9 @@ namespace EA
 
 #if defined(EA_DLL) && defined(EA_COMPILER_MSVC)
 	// re-enable warning 4251 (it's a level-1 warning and should not be suppressed globally)
-	#pragma warning(pop)
+	EA_RESTORE_VC_WARNING()
 #endif
 
 
 
 #endif // EATHREAD_EATHREAD_CONDITION_H
-
-
-
-
-
-
-
-
-
-

--- a/include/eathread/eathread_condition.h
+++ b/include/eathread/eathread_condition.h
@@ -22,7 +22,7 @@
 #include <eathread/eathread_mutex.h>
 
 
-#if defined(EA_DLL) && defined(_MSC_VER)
+#if defined(EA_DLL) && defined(EA_COMPILER_MSVC)
 	// Suppress warning about class 'EA::Thread::simple_list<T>' needs to have
 	// dll-interface to be used by clients of class which have a templated member.
 	// 
@@ -234,7 +234,7 @@ namespace EA
 
 
 
-#if defined(EA_DLL) && defined(_MSC_VER)
+#if defined(EA_DLL) && defined(EA_COMPILER_MSVC)
 	// re-enable warning 4251 (it's a level-1 warning and should not be suppressed globally)
 	#pragma warning(pop)
 #endif

--- a/include/eathread/eathread_futex.h
+++ b/include/eathread/eathread_futex.h
@@ -74,7 +74,7 @@
 	#include <mutex>
 	EA_RESTORE_VC_WARNING()
 
-#elif defined(__APPLE__)
+#elif defined(EA_PLATFORM_APPLE)
 	#if EATHREAD_MANUAL_FUTEX_ENABLED
 		#include <eathread/eathread_semaphore.h>
 		typedef EA::Thread::Semaphore EAFutexSemaphore;
@@ -149,9 +149,9 @@ namespace EA
 {
 	namespace Thread
 	{
-		#if defined(_WIN64)
+		#if defined(EA_PLATFORM_WIN64)
 			static const int FUTEX_PLATFORM_DATA_SIZE = 40; // CRITICAL_SECTION is 40 bytes on Win64.
-		#elif defined(_WIN32)
+		#elif defined(EA_PLATFORM_WIN32)
 			static const int FUTEX_PLATFORM_DATA_SIZE = 32; // CRITICAL_SECTION is 24 bytes on Win32 and 28 bytes on XBox 360.
 		#endif
 
@@ -288,7 +288,7 @@ namespace EA
 				#elif defined(EA_COMPILER_MSVC) && defined(EA_PLATFORM_MICROSOFT) // In the case of Microsoft platforms, we just use CRITICAL_SECTION, as it is essentially a futex.
 					// We use raw structure math because otherwise we'd expose the user to system headers, 
 					// which breaks code and bloats builds. We validate our math in eathread_futex.cpp.
-					#if defined(_WIN64)
+					#if defined(EA_PLATFORM_WIN64)
 						uint64_t mCRITICAL_SECTION[FUTEX_PLATFORM_DATA_SIZE / sizeof(uint64_t)];
 					#else
 						uint64_t mCRITICAL_SECTION[FUTEX_PLATFORM_DATA_SIZE / sizeof(uint64_t)];
@@ -704,7 +704,7 @@ namespace EA
 
 					// We use raw structure math because otherwise we'd expose the user to system headers, 
 					// which breaks code and bloats builds. We validate our math in eathread_futex.cpp.
-					#if defined(_WIN64)
+					#if defined(EA_PLATFORM_WIN64)
 						return *((int*)mCRITICAL_SECTION + 3); 
 					#else
 						return *((int*)mCRITICAL_SECTION + 2);
@@ -717,7 +717,7 @@ namespace EA
 
 					// We use raw structure math because otherwise we'd expose the user to system headers, 
 					// which breaks code and bloats builds. We validate our math in eathread_futex.cpp.
-					#if defined(_WIN64)
+					#if defined(EA_PLATFORM_WIN64)
 						return (*((uint32_t*)mCRITICAL_SECTION + 4) == (uintptr_t)GetCurrentThreadId());
 					#else
 						return (*((uint32_t*)mCRITICAL_SECTION + 3) == (uintptr_t)GetCurrentThreadId());
@@ -758,7 +758,7 @@ namespace EA
 				inline void Futex::SetSpinCount(Uint)
 				  { }
 
-			#endif // _MSC_VER
+			#endif // EA_COMPILER_MSVC
 
 		#endif // EATHREAD_MANUAL_FUTEX_ENABLED
 

--- a/include/eathread/eathread_mutex.h
+++ b/include/eathread/eathread_mutex.h
@@ -13,7 +13,7 @@
 #ifndef EATHREAD_EATHREAD_MUTEX_H
 #define EATHREAD_EATHREAD_MUTEX_H
 
-#if defined(_MSC_VER)
+#if defined(EA_COMPILER_MSVC)
 #include <math.h>   // #include math.h because VC++ has a header file but that requires math.h to be #included before some other headers, lest you get a warning.
 #endif
 #include <stddef.h>

--- a/include/eathread/eathread_pool.h
+++ b/include/eathread/eathread_pool.h
@@ -33,8 +33,7 @@
 	// These templates cannot be instantiated outside of the DLL. If you try, a
 	// link error will result. This compiler warning is intended to notify users
 	// of this.
-	#pragma warning(push)
-	#pragma warning(disable: 4251)
+	EA_DISABLE_VC_WARNING(4251)
 #endif
 
 #if defined(EA_PRAGMA_ONCE_SUPPORTED)
@@ -284,7 +283,7 @@ namespace EA
 
 #if defined(EA_DLL) && defined(EA_COMPILER_MSVC)
 	// re-enable warning 4251 (it's a level-1 warning and should not be suppressed globally)
-	#pragma warning(pop)
+	EA_RESTORE_VC_WARNING()
 #endif
 
 

--- a/include/eathread/eathread_pool.h
+++ b/include/eathread/eathread_pool.h
@@ -26,7 +26,7 @@
 #include <stddef.h>
 
 
-#if defined(EA_DLL) && defined(_MSC_VER)
+#if defined(EA_DLL) && defined(EA_COMPILER_MSVC)
 	// Suppress warning about class 'EA::Thread::simple_list<T>' needs to have
 	// dll-interface to be used by clients of class which have a templated member.
 	// 
@@ -282,7 +282,7 @@ namespace EA
 
 
 
-#if defined(EA_DLL) && defined(_MSC_VER)
+#if defined(EA_DLL) && defined(EA_COMPILER_MSVC)
 	// re-enable warning 4251 (it's a level-1 warning and should not be suppressed globally)
 	#pragma warning(pop)
 #endif

--- a/include/eathread/eathread_rwmutex_ip.h
+++ b/include/eathread/eathread_rwmutex_ip.h
@@ -27,13 +27,11 @@
 	#pragma once // Some compilers (e.g. VC++) benefit significantly from using this. We've measured 3-4% build speed improvements in apps as a result.
 #endif
 
-
-#ifdef _MSC_VER
+#ifdef EA_COMPILER_MSVC
 	#pragma warning(push)           // We have to be careful about disabling this warning. Sometimes the warning is meaningful; sometimes it isn't.
 	#pragma warning(disable: 4251)  // class (some template) needs to have dll-interface to be used by clients.
 	#pragma warning(disable: 6054)  // String 'argument 2' might not be zero-terminated
 #endif
-
 
 namespace EA
 {
@@ -413,18 +411,8 @@ namespace EA
 
 } // namespace EA
 
-
-
-#ifdef _MSC_VER
+#ifdef EA_COMPILER_MSVC
 	#pragma warning(pop)
 #endif
 
-
 #endif // EATHREAD_EATHREAD_RWMUTEX_IP_H
-
-
-
-
-
-
-

--- a/include/eathread/eathread_rwmutex_ip.h
+++ b/include/eathread/eathread_rwmutex_ip.h
@@ -18,20 +18,19 @@
 #include <eathread/eathread.h>
 #include <new>
 #if EA_WINAPI_FAMILY_PARTITION(EA_WINAPI_PARTITION_DESKTOP)
-	#pragma warning(push, 0)
+	EA_DISABLE_ALL_VC_WARNINGS()
 	#include <Windows.h>
-	#pragma warning(pop)
+	EA_RESTORE_ALL_VC_WARNINGS()
 #endif
 
 #if defined(EA_PRAGMA_ONCE_SUPPORTED)
 	#pragma once // Some compilers (e.g. VC++) benefit significantly from using this. We've measured 3-4% build speed improvements in apps as a result.
 #endif
 
-#ifdef EA_COMPILER_MSVC
-	#pragma warning(push)           // We have to be careful about disabling this warning. Sometimes the warning is meaningful; sometimes it isn't.
-	#pragma warning(disable: 4251)  // class (some template) needs to have dll-interface to be used by clients.
-	#pragma warning(disable: 6054)  // String 'argument 2' might not be zero-terminated
-#endif
+// We have to be careful about disabling this warning. Sometimes the warning is meaningful; sometimes it isn't.
+// 4251: class (some template) needs to have dll-interface to be used by clients.
+// 6054: String 'argument 2' might not be zero-terminated
+EA_DISABLE_VC_WARNING(4251 6054)
 
 namespace EA
 {
@@ -411,8 +410,6 @@ namespace EA
 
 } // namespace EA
 
-#ifdef EA_COMPILER_MSVC
-	#pragma warning(pop)
-#endif
+EA_RESTORE_VC_WARNING()
 
 #endif // EATHREAD_EATHREAD_RWMUTEX_IP_H

--- a/include/eathread/eathread_rwspinlock.h
+++ b/include/eathread/eathread_rwspinlock.h
@@ -17,8 +17,7 @@
 #include <eathread/eathread_atomic.h>
 #include <new>
 
-
-#ifdef _MSC_VER
+#ifdef EA_COMPILER_MSVC
 	 #pragma warning(push)
 	 #pragma warning(disable: 4100) // (Compiler claims pRWSpinLock is unreferenced)
 #endif
@@ -392,17 +391,8 @@ namespace EA
 
 } // namespace EA
 
-
-
-#ifdef _MSC_VER
+#ifdef EA_COMPILER_MSVC
 	#pragma warning(pop)
 #endif
 
-
 #endif // EATHREAD_EATHREAD_RWSPINLOCK_H
-
-
-
-
-
-

--- a/include/eathread/eathread_rwspinlock.h
+++ b/include/eathread/eathread_rwspinlock.h
@@ -17,10 +17,7 @@
 #include <eathread/eathread_atomic.h>
 #include <new>
 
-#ifdef EA_COMPILER_MSVC
-	 #pragma warning(push)
-	 #pragma warning(disable: 4100) // (Compiler claims pRWSpinLock is unreferenced)
-#endif
+EA_DISABLE_VC_WARNING(4100) // (Compiler claims pRWSpinLock is unreferenced)
 
 #if defined(EA_PRAGMA_ONCE_SUPPORTED)
 	#pragma once // Some compilers (e.g. VC++) benefit significantly from using this. We've measured 3-4% build speed improvements in apps as a result.
@@ -391,8 +388,6 @@ namespace EA
 
 } // namespace EA
 
-#ifdef EA_COMPILER_MSVC
-	#pragma warning(pop)
-#endif
+EA_RESTORE_VC_WARNING()
 
 #endif // EATHREAD_EATHREAD_RWSPINLOCK_H

--- a/include/eathread/eathread_rwspinlockw.h
+++ b/include/eathread/eathread_rwspinlockw.h
@@ -18,10 +18,7 @@
 #include <eathread/eathread_atomic.h>
 #include <new>
 
-#ifdef EA_COMPILER_MSVC
-	#pragma warning(push)
-	#pragma warning(disable: 4100) // (Compiler claims pRWSpinLockW is unreferenced)
-#endif
+EA_DISABLE_VC_WARNING(4100) // (Compiler claims pRWSpinLockW is unreferenced)
 
 #if defined(EA_PRAGMA_ONCE_SUPPORTED)
 	#pragma once // Some compilers (e.g. VC++) benefit significantly from using this. We've measured 3-4% build speed improvements in apps as a result.
@@ -428,8 +425,6 @@ namespace EA
 
 } // namespace EA
 
-#ifdef EA_COMPILER_MSVC
-	#pragma warning(pop)
-#endif
+EA_RESTORE_VC_WARNING()
 
 #endif // Header include guard

--- a/include/eathread/eathread_rwspinlockw.h
+++ b/include/eathread/eathread_rwspinlockw.h
@@ -18,8 +18,7 @@
 #include <eathread/eathread_atomic.h>
 #include <new>
 
-
-#ifdef _MSC_VER
+#ifdef EA_COMPILER_MSVC
 	#pragma warning(push)
 	#pragma warning(disable: 4100) // (Compiler claims pRWSpinLockW is unreferenced)
 #endif
@@ -429,24 +428,8 @@ namespace EA
 
 } // namespace EA
 
-
-
-#ifdef _MSC_VER
+#ifdef EA_COMPILER_MSVC
 	#pragma warning(pop)
 #endif
 
-
 #endif // Header include guard
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/include/eathread/eathread_semaphore.h
+++ b/include/eathread/eathread_semaphore.h
@@ -78,7 +78,7 @@
 		EASemaphoreData();
 	};
 
-#elif defined(__APPLE__)
+#elif defined(EA_PLATFORM_APPLE)
 
 	#include <mach/semaphore.h>
 	#include <eathread/eathread_atomic.h>

--- a/include/eathread/eathread_storage.h
+++ b/include/eathread/eathread_storage.h
@@ -96,18 +96,20 @@ namespace EA
 				#define EA_THREAD_LOCAL thread_local
 			#endif
 
-		#elif defined(__APPLE__)
+		#elif defined(EA_PLATFORM_APPLE)
 			// http://clang.llvm.org/docs/LanguageExtensions.html
 			#if __has_feature(cxx_thread_local)
 				#define EA_THREAD_LOCAL thread_local
 			#else
 				#define EA_THREAD_LOCAL 
 			#endif
-		#elif (defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 3)))) && (defined(EA_PLATFORM_WINDOWS) || defined(EA_PLATFORM_UNIX)) // Any of the Unix variants, including Mac OSX.
+		#elif ((defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 3))))) \
+			&& (defined(EA_PLATFORM_WINDOWS) || defined(EA_PLATFORM_UNIX)) // Any of the Unix variants, including Mac OSX.
 			// While GNUC v3.3 is the first version that supports thread local storage
 			// declarators, not all versions of GNUC for all platforms support it, 
 			// as it requires support from other tools and libraries beyond the compiler.
-			#if defined(__CYGWIN__) // Cygwin's branch of the GCC toolchain does not currently support TLS.
+			// Rafaël: Using __GNUC__ and __GNUC_MINOR__ here to put Clang in the equation too.
+			#if defined(EA_PLATFORM_CYGWIN) // Cygwin's branch of the GCC toolchain does not currently support TLS.
 				// Not supported.
 			#else
 				#define EA_THREAD_LOCAL __thread

--- a/include/eathread/eathread_thread.h
+++ b/include/eathread/eathread_thread.h
@@ -20,7 +20,7 @@ EA_RESTORE_ALL_VC_WARNINGS()
 
 
 
-#if defined(EA_DLL) && defined(_MSC_VER)
+#if defined(EA_DLL) && defined(EA_COMPILER_MSVC)
 	// Suppress warning about class 'AtomicInt32' needs to have a
 	// dll-interface to be used by clients of class which have a templated member.
 	// 
@@ -787,7 +787,7 @@ namespace EA
 } // namespace EA
 
 
-#if defined(EA_DLL) && defined(_MSC_VER)
+#if defined(EA_DLL) && defined(EA_COMPILER_MSVC)
 	// re-enable warning 4251 (it's a level-1 warning and should not be suppressed globally)
 	#pragma warning(pop)
 #endif

--- a/include/eathread/eathread_thread.h
+++ b/include/eathread/eathread_thread.h
@@ -27,8 +27,7 @@ EA_RESTORE_ALL_VC_WARNINGS()
 	// These templates cannot be instantiated outside of the DLL. If you try, a
 	// link error will result. This compiler warning is intended to notify users
 	// of this.
-	#pragma warning(push)
-	#pragma warning(disable: 4251)
+	EA_DISABLE_VC_WARNING(4251)
 #endif
 
 
@@ -789,14 +788,8 @@ namespace EA
 
 #if defined(EA_DLL) && defined(EA_COMPILER_MSVC)
 	// re-enable warning 4251 (it's a level-1 warning and should not be suppressed globally)
-	#pragma warning(pop)
+	EA_RESTORE_VC_WARNING()
 #endif
 
 
 #endif // EATHREAD_EATHREAD_THREAD_H
-
-
-
-
-
-

--- a/include/eathread/gcc/eathread_atomic_gcc.h
+++ b/include/eathread/gcc/eathread_atomic_gcc.h
@@ -73,7 +73,10 @@ namespace EA
 
 
 		// Recent versions of GCC have atomic primitives built into the compiler and standard library.
-		#if defined(EA_COMPILER_CLANG) || defined(__APPLE__) || (defined(__GNUC__) && (((__GNUC__ * 100) + __GNUC_MINOR__) >= 403)) || defined(EA_COMPILER_RVCT) // GCC 4.3 or later. Depends on the GCC implementation.
+		#if defined(EA_COMPILER_CLANG) \
+			|| defined(EA_PLATFORM_APPLE) \
+			|| (defined(EA_COMPILER_GNUC) && (EA_COMPILER_VERSION >= 4003)) \
+			|| defined(EA_COMPILER_RVCT) // GCC 4.3 or later. Depends on the GCC implementation.
 
 			template <> inline
 			AtomicInt<int32_t>::ValueType AtomicInt<int32_t>::GetValue() const

--- a/include/eathread/internal/config.h
+++ b/include/eathread/internal/config.h
@@ -114,7 +114,7 @@ EA_RESTORE_VC_WARNING()
 // Defined as 0 or 1
 //
 #ifndef EA_POSIX_THREADS_AVAILABLE
-	#if defined(__unix__) || defined(__linux__) || defined(__APPLE__) 
+	#if defined(EA_PLATFORM_UNIX) || defined(EA_PLATFORM_LINUX) || defined(EA_PLATFORM_APPLE)
 		#define EA_POSIX_THREADS_AVAILABLE 1
 	#elif defined(EA_PLATFORM_SONY)
 	   #define EA_POSIX_THREADS_AVAILABLE 0  // POSIX threading API is present but use is discouraged by Sony.  They want shipping code to use their scePthreads* API.
@@ -336,13 +336,13 @@ EA_RESTORE_VC_WARNING()
 //
 #ifndef EATHREADLIB_API // If the build file hasn't already defined this to be dllexport...
 	#if EATHREAD_DLL 
-		#if defined(_MSC_VER)
+		#if defined(EA_COMPILER_MSVC) || defined(EA_PLATFORM_MINGW)
 			#define EATHREADLIB_API      __declspec(dllimport)
 			#define EATHREADLIB_LOCAL
-		#elif defined(__CYGWIN__)
+		#elif defined(EA_PLATFORM_CYGWIN)
 			#define EATHREADLIB_API      __attribute__((dllimport))
 			#define EATHREADLIB_LOCAL
-		#elif (defined(__GNUC__) && (__GNUC__ >= 4))
+		#elif (defined(__GNUC__) && (__GNUC__ >= 4)) // GCC AND Clang
 			#define EATHREADLIB_API      __attribute__ ((visibility("default")))
 			#define EATHREADLIB_LOCAL    __attribute__ ((visibility("hidden")))
 		#else
@@ -429,7 +429,7 @@ EA_RESTORE_VC_WARNING()
 // of the operating system (ie: iOS 3) do not provide OS support for 64-bit
 // atomics while later versions (ie: iOS 4/5) do.
 #ifndef EATHREAD_HAS_EMULATED_AND_NATIVE_ATOMICS
-	#if defined(__APPLE__)
+	#if defined(EA_PLATFORM_APPLE)
 		#define EATHREAD_HAS_EMULATED_AND_NATIVE_ATOMICS 1 
 	#else
 		#define EATHREAD_HAS_EMULATED_AND_NATIVE_ATOMICS 0
@@ -444,7 +444,7 @@ EA_RESTORE_VC_WARNING()
 // And even then it's available only some of the time.
 //
 #if !defined(EATHREAD_GLIBC_BACKTRACE_AVAILABLE)
-	#if (defined(__clang__) || defined(__GNUC__)) && (defined(EA_PLATFORM_LINUX) || defined(__APPLE__)) && !defined(__CYGWIN__) && !defined(EA_PLATFORM_ANDROID)
+	#if (defined(EA_COMPILER_CLANG) || defined(EA_COMPILER_GNUC)) && (defined(EA_PLATFORM_LINUX) || defined(EA_PLATFORM_APPLE)) && !defined(EA_PLATFORM_CYGWIN) && !defined(EA_PLATFORM_ANDROID)
 		#define EATHREAD_GLIBC_BACKTRACE_AVAILABLE 1
 	#else
 		#define EATHREAD_GLIBC_BACKTRACE_AVAILABLE 0
@@ -578,7 +578,7 @@ EA_RESTORE_VC_WARNING()
 // EATHREAD_DEBUG_BREAK
 //
 #ifndef EATHREAD_DEBUG_BREAK
-	#ifdef __MSC_VER
+	#ifdef EA_COMPILER_MSVC
 		#define EATHREAD_DEBUG_BREAK() __debugbreak()
 	#else
 		#define EATHREAD_DEBUG_BREAK() *(volatile int*)(0) = 0

--- a/include/eathread/x86-64/eathread_atomic_x86-64.h
+++ b/include/eathread/x86-64/eathread_atomic_x86-64.h
@@ -20,15 +20,13 @@
 
 
 #ifdef EA_COMPILER_MSVC
-	#pragma warning(push, 0)
+	EA_DISABLE_ALL_VC_WARNINGS()
 	#include <math.h>   // VS2008 has an acknowledged bug that requires math.h (and possibly also string.h) to be #included before intrin.h.
 	#include <intrin.h>
-	#pragma warning(pop)
-
-	#pragma warning(push)
-	#pragma warning(disable: 4146)  // unary minus operator applied to unsigned type, result still unsigned
+	EA_RESTORE_ALL_VC_WARNINGS()
 #endif
 
+EA_DISABLE_VC_WARNING(4146)  // unary minus operator applied to unsigned type, result still unsigned
 
 #if defined(EA_PROCESSOR_X86_64)
 
@@ -440,8 +438,6 @@
 
 #endif // EA_PROCESSOR_X86_64
 
-#ifdef EA_COMPILER_MSVC
-	 #pragma warning(pop)
-#endif
+EA_RESTORE_VC_WARNING()
 
 #endif // EATHREAD_X86_64_EATHREAD_ATOMIC_X86_64_H

--- a/include/eathread/x86-64/eathread_atomic_x86-64.h
+++ b/include/eathread/x86-64/eathread_atomic_x86-64.h
@@ -19,7 +19,7 @@
 #include <eathread/internal/eathread_atomic_standalone.h>
 
 
-#ifdef _MSC_VER
+#ifdef EA_COMPILER_MSVC
 	#pragma warning(push, 0)
 	#include <math.h>   // VS2008 has an acknowledged bug that requires math.h (and possibly also string.h) to be #included before intrin.h.
 	#include <intrin.h>
@@ -41,7 +41,7 @@
 			///
 			/// Non-member 128-bit Atomics implementation 
 			///
-			#if (_MSC_VER >= 1500) // VS2008+
+			#if (EA_COMPILER_MSVC >= 1500) // VS2008+
 
 				#define EATHREAD_ATOMIC_128_SUPPORTED 1
 
@@ -72,7 +72,7 @@
 
 			#elif defined(EA_COMPILER_GNUC) || defined(EA_COMPILER_CLANG)
 
-				#if defined(EA_COMPILER_CLANG) || (defined(__GNUC__) && (((__GNUC__ * 100) + __GNUC_MINOR__) >= 403)) // GCC 4.3 or later for 128 bit atomics
+				#if defined(EA_COMPILER_CLANG) || (defined(EA_COMPILER_GNUC) && EA_COMPILER_VERSION >= 4003) // GCC 4.3 or later for 128 bit atomics
 
 					#define EATHREAD_ATOMIC_128_SUPPORTED 1
 
@@ -328,7 +328,7 @@
 			#elif defined(EA_COMPILER_GNUC) || defined(EA_COMPILER_CLANG)
 
 				// Recent versions of GCC have atomic primitives built into the compiler and standard library.
-				#if defined(EA_COMPILER_CLANG) || (defined(__GNUC__) && (((__GNUC__ * 100) + __GNUC_MINOR__) >= 401)) // GCC 4.1 or later
+				#if defined(EA_COMPILER_CLANG) || (defined(EA_COMPILER_GNUC) && EA_COMPILER_VERSION >= 4001) // GCC 4.1 or later
 
 					template <> inline
 					AtomicInt<int32_t>::ValueType AtomicInt<int32_t>::GetValue() const
@@ -440,23 +440,8 @@
 
 #endif // EA_PROCESSOR_X86_64
 
-
-#ifdef _MSC_VER
+#ifdef EA_COMPILER_MSVC
 	 #pragma warning(pop)
 #endif
 
-
 #endif // EATHREAD_X86_64_EATHREAD_ATOMIC_X86_64_H
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/include/eathread/x86-64/eathread_sync_x86-64.h
+++ b/include/eathread/x86-64/eathread_sync_x86-64.h
@@ -23,7 +23,7 @@
 #if defined(EA_PROCESSOR_X86_64)
 	#define EA_THREAD_SYNC_IMPLEMENTED
 
-	#ifdef _MSC_VER
+	#ifdef EA_COMPILER_MSVC
 		#pragma warning(push, 0)
 		#include <math.h>   // VS2008 has an acknowledged bug that requires math.h (and possibly also string.h) to be #included before intrin.h.
 		#include <intrin.h>
@@ -73,7 +73,7 @@
 		#define EAReadBarrier()      __asm__ __volatile__ ("lfence" ::: "memory");
 		#define EAWriteBarrier()     __asm__ __volatile__ ("sfence" ::: "memory");
 		#define EAReadWriteBarrier() __asm__ __volatile__ ("mfence" ::: "memory");
-	#elif defined(__GNUC__) && (((__GNUC__ * 100) + __GNUC_MINOR__) >= 401) // GCC 4.1 or later
+	#elif defined(__GNUC__) && (((__GNUC__ * 100) + __GNUC_MINOR__) >= 401) // GCC 4.1 or later, includes clang
 		#define EAReadBarrier      __sync_synchronize
 		#define EAWriteBarrier     __sync_synchronize
 		#define EAReadWriteBarrier __sync_synchronize

--- a/include/eathread/x86-64/eathread_sync_x86-64.h
+++ b/include/eathread/x86-64/eathread_sync_x86-64.h
@@ -24,10 +24,10 @@
 	#define EA_THREAD_SYNC_IMPLEMENTED
 
 	#ifdef EA_COMPILER_MSVC
-		#pragma warning(push, 0)
+		EA_DISABLE_ALL_VC_WARNINGS()
 		#include <math.h>   // VS2008 has an acknowledged bug that requires math.h (and possibly also string.h) to be #included before intrin.h.
 		#include <intrin.h>
-		#pragma warning(pop)
+		EA_RESTORE_ALL_VC_WARNINGS()
 	#endif
 
 	// By default, we define EA_TARGET_SMP to be true. The reason for this is that most 

--- a/include/eathread/x86/eathread_atomic_x86.h
+++ b/include/eathread/x86/eathread_atomic_x86.h
@@ -19,13 +19,9 @@
 #include <stddef.h>
 #include <eathread/internal/eathread_atomic_standalone.h>
 
-
-#ifdef EA_COMPILER_MSVC
-	 #pragma warning(push)
-	 #pragma warning(disable: 4146)  // unary minus operator applied to unsigned type, result still unsigned
-	 #pragma warning(disable: 4339)  // use of undefined type detected in CLR meta-data
-#endif
-
+// 4146: unary minus operator applied to unsigned type, result still unsigned
+// 4339: use of undefined type detected in CLR meta-data
+EA_DISABLE_VC_WARNING(4146 4339)
 
 // This is required for Windows Phone (ARM) because we are temporarily not using
 // CPP11 style atomics and we are depending on the MSVC intrinics.
@@ -720,23 +716,6 @@
 
 #endif // EA_PROCESSOR_X86
 
-
-#ifdef EA_COMPILER_MSVC
-	 #pragma warning(pop)
-#endif
-
+EA_RESTORE_VC_WARNING()
 
 #endif // EATHREAD_X86_EATHREAD_ATOMIC_X86_H
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/include/eathread/x86/eathread_atomic_x86.h
+++ b/include/eathread/x86/eathread_atomic_x86.h
@@ -20,7 +20,7 @@
 #include <eathread/internal/eathread_atomic_standalone.h>
 
 
-#ifdef _MSC_VER
+#ifdef EA_COMPILER_MSVC
 	 #pragma warning(push)
 	 #pragma warning(disable: 4146)  // unary minus operator applied to unsigned type, result still unsigned
 	 #pragma warning(disable: 4339)  // use of undefined type detected in CLR meta-data
@@ -95,7 +95,7 @@
 				volatile ValueType mValue;
 			};
 
-			#if defined(EA_PLATFORM_MICROSOFT) && defined(_MSC_VER)
+			#if defined(EA_PLATFORM_MICROSOFT) && defined(EA_COMPILER_MSVC)
 
 				// 32 bit versions
 				template<> inline
@@ -251,7 +251,7 @@
 			#elif defined(EA_COMPILER_GNUC) || defined (EA_COMPILER_CLANG)
 
 				// Recent versions of GCC have atomic primitives built into the compiler and standard library.
-				#if defined (EA_COMPILER_CLANG) || defined(__APPLE__) || (defined(__GNUC__) && (((__GNUC__ * 100) + __GNUC_MINOR__) >= 403)) // GCC 4.3 or later
+				#if defined (EA_COMPILER_CLANG) || defined(EA_PLATFORM_APPLE) || (defined(EA_COMPILER_GNUC) && EA_COMPILER_VERSION >= 4003) // GCC 4.3 or later
 
 					template <> inline
 					AtomicInt<int32_t>::ValueType AtomicInt<int32_t>::GetValue() const
@@ -721,7 +721,7 @@
 #endif // EA_PROCESSOR_X86
 
 
-#ifdef _MSC_VER
+#ifdef EA_COMPILER_MSVC
 	 #pragma warning(pop)
 #endif
 

--- a/include/eathread/x86/eathread_sync_x86.h
+++ b/include/eathread/x86/eathread_sync_x86.h
@@ -53,7 +53,7 @@
 	// We define EAReadBarrier here to be the same as EACompilerMemory barrier in order to limit the 
 	// compiler from making any assumptions at its level about memory usage. Year 2003+ versions of the 
 	// Microsoft SDK define a 'MemoryBarrier' statement which has the same effect as EAReadWriteBarrier.
-	#if defined(__GNUC__) && (((__GNUC__ * 100) + __GNUC_MINOR__) >= 401) // GCC 4.1 or later
+	#if defined(__GNUC__) && (((__GNUC__ * 100) + __GNUC_MINOR__) >= 401) // GCC 4.1 or later, includes clang
 		#define EAReadBarrier      __sync_synchronize
 		#define EAWriteBarrier     __sync_synchronize
 		#define EAReadWriteBarrier __sync_synchronize

--- a/source/apple/eathread_callstack_apple.cpp
+++ b/source/apple/eathread_callstack_apple.cpp
@@ -31,7 +31,7 @@
 #endif
 
 
-#if defined(__LP64__)
+#if EA_PLATFORM_PTR_SIZE == 8
 typedef struct mach_header_64     MachHeader;
 typedef struct segment_command_64 SegmentCommand;
 typedef struct section_64         Section;

--- a/source/arm/eathread_callstack_arm.cpp
+++ b/source/arm/eathread_callstack_arm.cpp
@@ -168,14 +168,14 @@ EATHREADLIB_API void ShutdownCallstack()
 			context = *pContext;
 		else
 		{
-			#if defined(__ARMCC_VERSION)
+			#if defined(EA_COMPILER_ARM)
 				context.mFP = 0; // We don't currently have a simple way to read fp (which is r7 (Thumb) or r11 (ARM)).
 				context.mSP = (uintptr_t)__current_sp();
 				context.mLR = (uintptr_t)__return_address();
 				GetInstructionPointer(p); // Intentionally don't call __current_pc() or EAGetInstructionPointer, because these won't set the Thumb bit it this is Thumb code.
 				context.mPC = (uintptr_t)p;
 
-			#elif defined(__GNUC__) || defined(EA_COMPILER_CLANG) // Including Apple iOS.
+			#elif defined(EA_COMPILER_GNUC) || defined(EA_COMPILER_CLANG) // Including Apple iOS.
 				void* spAddress = &context.mSP;
 				void* sp;
 				asm volatile(
@@ -201,7 +201,7 @@ EATHREADLIB_API void ShutdownCallstack()
 			#endif
 		}
 
-		#if defined(__APPLE__)
+		#if defined(EA_PLATFORM_APPLE)
 			// We have reason to believe that the following should be reliable. But if it's not then we should
 			// just call the code below.
 			entryCount = GetCallstackARMApple(pReturnAddressArray, nReturnAddressArrayCapacity, &context);
@@ -275,12 +275,12 @@ EATHREADLIB_API bool GetCallstackContext(CallstackContext& context, intptr_t thr
 			void* p;
 
 			// TODO: make defines of this so that the implementation between us and GetCallstack remains the same
-			#if defined(__ARMCC_VERSION)
+			#if defined(EA_COMPILER_ARM)
 				context.mSP = (uint32_t)__current_sp();
 				context.mLR = (uint32_t)__return_address();
 				context.mPC = (uint32_t)__current_pc();
 
-			#elif defined(__GNUC__) || defined(EA_COMPILER_CLANG)
+			#elif defined(EA_COMPILER_GNUC) || defined(EA_COMPILER_CLANG)
 				// register uintptr_t current_sp asm ("sp");
 				p = __builtin_frame_address(0);
 				context.mSP = (uintptr_t)p;
@@ -291,7 +291,7 @@ EATHREADLIB_API bool GetCallstackContext(CallstackContext& context, intptr_t thr
 				EAGetInstructionPointer(p);
 				context.mPC = reinterpret_cast<uintptr_t>(p);
 
-			#elif defined(_MSC_VER)
+			#elif defined(EA_COMPILER_MSVC)
 				context.mSP = 0;
 
 				#error EACallstack::GetCallstack: Need a way to get the return address (register 14)
@@ -347,9 +347,9 @@ EATHREADLIB_API void SetStackBase(void* pStackBase)
 		// Can't call GetStackLimit() because doing so would disturb the stack. 
 		// As of this writing, we don't have an EAGetStackTop macro which could do this.
 		// So we implement it inline here.
-		#if   defined(__ARMCC_VERSION)
+		#if   defined(EA_COMPILER_ARM)
 			pStackBase = (void*)__current_sp();
-		#elif defined(__GNUC__) || defined(EA_COMPILER_CLANG)
+		#elif defined(EA_COMPILER_GNUC) || defined(EA_COMPILER_CLANG)
 			pStackBase = __builtin_frame_address(0);
 		#endif
 
@@ -389,9 +389,9 @@ EATHREADLIB_API void* GetStackLimit()
 			return pLimit;
 	#endif
 
-	#if   defined(__ARMCC_VERSION)
+	#if   defined(EA_COMPILER_ARM)
 		void* pStack = (void*)__current_sp();
-	#elif defined(__GNUC__) || defined(EA_COMPILER_CLANG)
+	#elif defined(EA_COMPILER_GNUC) || defined(EA_COMPILER_CLANG)
 		void* pStack = __builtin_frame_address(0);
 	#else
 		void* pStack = NULL;  // TODO:  determine fix.

--- a/source/arm/eathread_callstack_arm.cpp
+++ b/source/arm/eathread_callstack_arm.cpp
@@ -13,10 +13,10 @@
 #endif
 
 #if defined(EA_PLATFORM_WINDOWS) && EA_WINAPI_FAMILY_PARTITION(EA_WINAPI_PARTITION_DESKTOP)
-	#pragma warning(push, 0)
+	EA_DISABLE_ALL_VC_WARNINGS()
 	#include <Windows.h>
 	#include <winternl.h>
-	#pragma warning(pop)
+	EA_RESTORE_ALL_VC_WARNINGS()
 #endif
 
 #if defined(EA_PLATFORM_UNIX)

--- a/source/cpp11/eathread_cpp11.cpp
+++ b/source/cpp11/eathread_cpp11.cpp
@@ -47,7 +47,7 @@ namespace EA
 					std::thread::id stdId = std::this_thread::get_id();
 					EAT_COMPILETIME_ASSERT(sizeof(_Thrd_t) == sizeof(std::thread::id));
 					return ((_Thrd_t&)stdId)._Hnd;
-				#elif EA_POSIX_THREADS_AVAILABLE && defined(_YVALS)
+				#elif EA_POSIX_THREADS_AVAILABLE && defined(EA_HAVE_DINKUMWARE_CPP_LIBRARY)
 					std::thread::id stdId = std::this_thread::get_id();
 					EAT_COMPILETIME_ASSERT(sizeof(_Thrd_t) == sizeof(std::thread::id));
 					return reinterpret_cast<_Thrd_t>(stdId);

--- a/source/eathread.cpp
+++ b/source/eathread.cpp
@@ -216,7 +216,7 @@ namespace EA
 
 		#elif defined(EA_PLATFORM_UNIX) || EA_POSIX_THREADS_AVAILABLE
 
-			#if defined(EA_PLATFORM_LINUX) || defined(__CYGWIN__) || (_POSIX_TIMERS > 0)
+			#if defined(EA_PLATFORM_LINUX) || defined(EA_PLATFORM_CYGWIN) || (_POSIX_TIMERS > 0)
 				ThreadTime threadTime;
 				clock_gettime(CLOCK_REALTIME, &threadTime);  // If you get a linker error about clock_getttime, you need to link librt.a (specify -lrt to the linker).
 				return threadTime;

--- a/source/eathread_callstack.cpp
+++ b/source/eathread_callstack.cpp
@@ -25,10 +25,10 @@
 	#if !defined(EA_PLATFORM_MICROSOFT)
 		#include "unix/eathread_pthread_stack_info.cpp"
 	#endif
-#elif (defined(EA_PLATFORM_LINUX) || defined(__CYGWIN__)) && (defined(EA_PROCESSOR_X86) || defined(EA_PROCESSOR_X86_64))
+#elif (defined(EA_PLATFORM_LINUX) || defined(EA_PLATFORM_CYGWIN)) && (defined(EA_PROCESSOR_X86) || defined(EA_PROCESSOR_X86_64))
 	#include "x86/eathread_callstack_x86.cpp"
 	#include "unix/eathread_pthread_stack_info.cpp"
-#elif defined(__GNUC__) || defined(EA_COMPILER_CLANG)
+#elif defined(EA_COMPILER_GNUC) || defined(EA_COMPILER_CLANG)
 	#include "unix/eathread_callstack_glibc.cpp"
 	#include "unix/eathread_pthread_stack_info.cpp"
 #else

--- a/source/eathread_futex.cpp
+++ b/source/eathread_futex.cpp
@@ -35,7 +35,7 @@
 		return true;
 	}
 
-#elif defined(__APPLE__) && EATHREAD_MANUAL_FUTEX_ENABLED
+#elif defined(EA_PLATFORM_APPLE) && EATHREAD_MANUAL_FUTEX_ENABLED
 	#include <semaphore.h>
 	#include <stdio.h>
 	#include <errno.h>
@@ -180,7 +180,7 @@
 
 	void EA::Thread::Futex::DestroyFSemaphore()
 	{
-		#if defined (__APPLE__)
+		#if defined (EA_PLATFORM_APPLE)
 			sem_close(&mSemaphore);
 		#elif defined(EA_PLATFORM_ANDROID)
 			sem_destroy(&mSemaphore);   // Android's sem_destroy is broken. http://code.google.com/p/android/issues/detail?id=3106

--- a/source/eathread_futex.cpp
+++ b/source/eathread_futex.cpp
@@ -222,9 +222,9 @@
 
 #elif defined(EA_PLATFORM_MICROSOFT) && !EA_USE_CPP11_CONCURRENCY && !EATHREAD_MANUAL_FUTEX_ENABLED
 
-	#pragma warning(push, 0)
+	EA_DISABLE_ALL_VC_WARNINGS()
 	#include <Windows.h>
-	#pragma warning(pop)
+	EA_RESTORE_ALL_VC_WARNINGS()
 
 	// Validate what we assume to be invariants.
 	EAT_COMPILETIME_ASSERT(sizeof(CRITICAL_SECTION) <= (EA::Thread::FUTEX_PLATFORM_DATA_SIZE / sizeof(uint64_t) * sizeof(uint64_t)));
@@ -243,9 +243,9 @@
 #elif defined(EA_PLATFORM_MICROSOFT) && EATHREAD_MANUAL_FUTEX_ENABLED
 
 	#if defined(EA_PLATFORM_WINDOWS)
-		#pragma warning(push, 0)
+		EA_DISABLE_ALL_VC_WARNINGS()
 		#include <Windows.h>
-		#pragma warning(pop)
+		EA_RESTORE_ALL_VC_WARNINGS()
 	#endif
 
 	void EA::Thread::Futex::CreateFSemaphore()

--- a/source/eathread_pool.cpp
+++ b/source/eathread_pool.cpp
@@ -8,7 +8,7 @@
 #include <string.h>
 #include <new>
 
-#if   defined(_MSC_VER)
+#if defined(EA_COMPILER_MSVC)
 	#pragma warning(push)
 	#pragma warning(disable: 6011) // Dereferencing NULL pointer 'gpAllocator'
 	#pragma warning(disable: 6211) // Leaking memory 'pThreadInfo' due to an exception.
@@ -91,7 +91,7 @@ EA::Thread::ThreadPool::~ThreadPool()
 }
 
 
-#ifdef _MSC_VER
+#ifdef EA_COMPILER_MSVC
 	#pragma warning(push)
 	#pragma warning(disable: 4296 4706) // '>=' : expression is always true and assignment within conditional expression (in the assert)
 #endif
@@ -169,7 +169,7 @@ bool EA::Thread::ThreadPool::Init(const ThreadPoolParameters* pThreadPoolParamet
 }
 
 
-#ifdef _MSC_VER
+#ifdef EA_COMPILER_MSVC
 	#pragma warning(pop)
 #endif
 
@@ -704,7 +704,7 @@ void EA::Thread::ThreadPoolFactory::DestructThreadPool(EA::Thread::ThreadPool* p
 }
 
 
-#if defined(_MSC_VER)
+#if defined(EA_COMPILER_MSVC)
 	#pragma warning(pop)
 #endif
 

--- a/source/eathread_pool.cpp
+++ b/source/eathread_pool.cpp
@@ -8,13 +8,10 @@
 #include <string.h>
 #include <new>
 
-#if defined(EA_COMPILER_MSVC)
-	#pragma warning(push)
-	#pragma warning(disable: 6011) // Dereferencing NULL pointer 'gpAllocator'
-	#pragma warning(disable: 6211) // Leaking memory 'pThreadInfo' due to an exception.
-	#pragma warning(disable: 6326) // Potential comparison of a constant with another constant
-#endif
-
+// 6011: Dereferencing NULL pointer 'gpAllocator'
+// 6211: Leaking memory 'pThreadInfo' due to an exception.
+// 6326: Potential comparison of a constant with another constant
+EA_DISABLE_VC_WARNING(6011 6211 6326)
 
 namespace EA
 {
@@ -91,10 +88,7 @@ EA::Thread::ThreadPool::~ThreadPool()
 }
 
 
-#ifdef EA_COMPILER_MSVC
-	#pragma warning(push)
-	#pragma warning(disable: 4296 4706) // '>=' : expression is always true and assignment within conditional expression (in the assert)
-#endif
+EA_DISABLE_VC_WARNING(4296 4706) // '>=' : expression is always true and assignment within conditional expression (in the assert)
 
 
 #if EAT_ASSERT_ENABLED
@@ -169,9 +163,7 @@ bool EA::Thread::ThreadPool::Init(const ThreadPoolParameters* pThreadPoolParamet
 }
 
 
-#ifdef EA_COMPILER_MSVC
-	#pragma warning(pop)
-#endif
+EA_RESTORE_VC_WARNING() // 4296 4706
 
 
 bool EA::Thread::ThreadPool::Shutdown(JobWait jobWait, const ThreadTime& timeoutAbsolute)
@@ -703,9 +695,4 @@ void EA::Thread::ThreadPoolFactory::DestructThreadPool(EA::Thread::ThreadPool* p
 	pThreadPool->~ThreadPool();
 }
 
-
-#if defined(EA_COMPILER_MSVC)
-	#pragma warning(pop)
-#endif
-
-
+EA_RESTORE_VC_WARNING()

--- a/source/eathread_rwmutex.cpp
+++ b/source/eathread_rwmutex.cpp
@@ -1,13 +1,11 @@
-///////////////////////////////////////////////////////////////////////////////
+﻿///////////////////////////////////////////////////////////////////////////////
 // Copyright (c) Electronic Arts Inc. All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <EABase/eabase.h>
 
-#if defined(EA_COMPILER_MSVC)
-	#pragma warning(disable: 4985)  // 'ceil': attributes not present on previous declaration.1>    C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\INCLUDE\intrin.h(142) : see declaration of 'ceil'
-#endif
 
+EA_DISABLE_VC_WARNING(4985)  // 'ceil': attributes not present on previous declaration.1>    C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\INCLUDE\intrin.h(142) : see declaration of 'ceil'
 
 #include <eathread/internal/config.h>
 #include <eathread/eathread_rwmutex.h>
@@ -15,10 +13,7 @@
 #include <new> // include new for placement new operator
 #include <string.h>
 
-#ifdef EA_COMPILER_MSVC
-	#pragma warning(disable : 4996) // This function or variable may be unsafe / deprecated.
-#endif
-
+EA_DISABLE_VC_WARNING(4996) // This function or variable may be unsafe / deprecated.
 
 	EARWMutexData::EARWMutexData()
 	  : mnReadWaiters(0), 
@@ -259,7 +254,5 @@ void EA::Thread::RWMutexFactory::DestructRWMutex(EA::Thread::RWMutex* pRWMutex)
 	pRWMutex->~RWMutex();
 }
 
-
-
-
-
+EA_RESTORE_VC_WARNING() // 4996
+EA_RESTORE_VC_WARNING() // 4985

--- a/source/eathread_rwmutex.cpp
+++ b/source/eathread_rwmutex.cpp
@@ -2,7 +2,9 @@
 // Copyright (c) Electronic Arts Inc. All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#if defined(_MSC_VER)
+#include <EABase/eabase.h>
+
+#if defined(EA_COMPILER_MSVC)
 	#pragma warning(disable: 4985)  // 'ceil': attributes not present on previous declaration.1>    C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\INCLUDE\intrin.h(142) : see declaration of 'ceil'
 #endif
 
@@ -13,7 +15,7 @@
 #include <new> // include new for placement new operator
 #include <string.h>
 
-#ifdef _MSC_VER
+#ifdef EA_COMPILER_MSVC
 	#pragma warning(disable : 4996) // This function or variable may be unsafe / deprecated.
 #endif
 

--- a/source/eathread_semaphore.cpp
+++ b/source/eathread_semaphore.cpp
@@ -16,7 +16,7 @@ EA_RESTORE_VC_WARNING()
 	// Fall through.
 #elif 0 //EA_USE_CPP11_CONCURRENCY
 	#include "cpp11/eathread_semaphore_cpp11.cpp"
-#elif defined(__APPLE__)
+#elif defined(EA_PLATFORM_APPLE)
 	#include "apple/eathread_semaphore_apple.cpp"
 #elif defined(EA_PLATFORM_ANDROID)
 	#include "android/eathread_semaphore_android.cpp"

--- a/source/eathread_storage.cpp
+++ b/source/eathread_storage.cpp
@@ -47,9 +47,9 @@ EA_RESTORE_VC_WARNING()
 	#if defined(EA_PLATFORM_UNIX)
 		#include <unistd.h>
 	#elif defined(EA_PLATFORM_WINDOWS)
-		#pragma warning(push, 0)
+		EA_DISABLE_ALL_VC_WARNINGS()
 		#include <Windows.h>
-		#pragma warning(pop)
+		EA_RESTORE_ALL_VC_WARNINGS()
 	#endif
 
 	EA::Thread::ThreadLocalStorage::ThreadLocalStorage()
@@ -84,9 +84,9 @@ EA_RESTORE_VC_WARNING()
 
 
 #elif defined(EA_PLATFORM_MICROSOFT) && !defined(EA_PLATFORM_WINDOWS_PHONE) && !(defined(EA_PLATFORM_WINDOWS) && !EA_WINAPI_FAMILY_PARTITION(EA_WINAPI_PARTITION_DESKTOP)) 
-		#pragma warning(push, 0)
+		EA_DISABLE_ALL_VC_WARNINGS()
 		#include <Windows.h>
-		#pragma warning(pop)
+		EA_RESTORE_ALL_VC_WARNINGS()
 
 	EA::Thread::ThreadLocalStorage::ThreadLocalStorage()
 		: mTLSData(TlsAlloc())
@@ -348,7 +348,3 @@ void EA::Thread::ThreadLocalStorageFactory::DestructThreadLocalStorage(EA::Threa
 
 #undef OSEnableInterrupts   
 #undef OSDisableInterrupts
-
-
-
-

--- a/source/kettle/eathread_kettle.cpp
+++ b/source/kettle/eathread_kettle.cpp
@@ -10,7 +10,7 @@
 
 #include <sched.h>
 #include <unistd.h>
-#if defined(_YVALS)
+#if defined(EA_HAVE_DINKUMWARE_CPP_LIBRARY)
 	#include <time.h>
 #else
 	#include <sys/time.h>

--- a/source/libunwind/eathread_callstack_libunwind.cpp
+++ b/source/libunwind/eathread_callstack_libunwind.cpp
@@ -316,13 +316,13 @@ EATHREADLIB_API bool GetCallstackContext(CallstackContext& context, intptr_t thr
 		   (threadId == (intptr_t)EA::Thread::GetThreadId()))
 		{
 			// Note: the behavior below is inconsistent between platforms and needs to be made so.
-			#if defined(__ARMCC_VERSION) // If using the ARM Compiler...
+			#if defined(EA_COMPILER_ARM) // If using the ARM Compiler...
 				context.mSP           = (uint32_t)__current_sp();
 				context.mLR           = (uint32_t)__return_address();
 				context.mPC           = (uint32_t)__current_pc();
 				context.mStackPointer = context.mSP;
 
-			#elif defined(__GNUC__) || defined(EA_COMPILER_CLANG)                
+			#elif defined(EA_COMPILER_GNUC) || defined(EA_COMPILER_CLANG)
 				#if defined(EA_PROCESSOR_X86_64)
 					context.mRIP          = (uint64_t)__builtin_return_address(0);
 					context.mRSP          = (uint64_t)__builtin_frame_address(1);

--- a/source/null/eathread_callstack_null.cpp
+++ b/source/null/eathread_callstack_null.cpp
@@ -7,11 +7,7 @@
 #include <eathread/eathread_storage.h>
 #include <string.h>
 
-
-#if defined(EA_COMPILER_MSVC)
-	#pragma warning(disable: 4172) // returning address of local variable or temporary
-#endif
-
+EA_DISABLE_VC_WARNING(4172) // returning address of local variable or temporary
 
 namespace EA
 {
@@ -118,5 +114,4 @@ EATHREADLIB_API void* GetStackLimit()
 } // namespace Thread
 } // namespace EA
 
-
-
+EA_RESTORE_VC_WARNING()

--- a/source/null/eathread_callstack_null.cpp
+++ b/source/null/eathread_callstack_null.cpp
@@ -8,7 +8,7 @@
 #include <string.h>
 
 
-#if defined(_MSC_VER)
+#if defined(EA_COMPILER_MSVC)
 	#pragma warning(disable: 4172) // returning address of local variable or temporary
 #endif
 

--- a/source/pc/eathread_callstack_win32.cpp
+++ b/source/pc/eathread_callstack_win32.cpp
@@ -9,7 +9,7 @@
 
 #if defined(EA_PLATFORM_WIN32) && EA_WINAPI_FAMILY_PARTITION(EA_WINAPI_PARTITION_DESKTOP) // The following only works on Win32 and not Win64.
 
-#if defined(_MSC_VER)
+#if defined(EA_COMPILER_MSVC)
 	#pragma warning(push, 0)
 #endif
 
@@ -17,12 +17,12 @@
 #include <DbgHelp.h>
 #include <stdio.h>
 
-#if defined(_MSC_VER)
+#if defined(EA_COMPILER_MSVC)
 	#pragma warning(pop)
 #endif
 
 
-#ifdef _MSC_VER
+#ifdef EA_COMPILER_MSVC
 	#pragma warning(disable: 4740)      // flow in or out of inline asm code suppresses global optimization
 	#pragma comment(lib, "dbghelp.lib")
 	#pragma comment(lib, "psapi.lib")

--- a/source/pc/eathread_callstack_win32.cpp
+++ b/source/pc/eathread_callstack_win32.cpp
@@ -9,21 +9,14 @@
 
 #if defined(EA_PLATFORM_WIN32) && EA_WINAPI_FAMILY_PARTITION(EA_WINAPI_PARTITION_DESKTOP) // The following only works on Win32 and not Win64.
 
-#if defined(EA_COMPILER_MSVC)
-	#pragma warning(push, 0)
-#endif
-
+EA_DISABLE_ALL_VC_WARNINGS()
 #include <Windows.h>
 #include <DbgHelp.h>
 #include <stdio.h>
+EA_RESTORE_ALL_VC_WARNINGS()
 
-#if defined(EA_COMPILER_MSVC)
-	#pragma warning(pop)
-#endif
-
-
+EA_DISABLE_VC_WARNING(4740)      // flow in or out of inline asm code suppresses global optimization
 #ifdef EA_COMPILER_MSVC
-	#pragma warning(disable: 4740)      // flow in or out of inline asm code suppresses global optimization
 	#pragma comment(lib, "dbghelp.lib")
 	#pragma comment(lib, "psapi.lib")
 #endif
@@ -532,5 +525,6 @@ EATHREADLIB_API size_t GetCallstack(void* pReturnAddressArray[], size_t nReturnA
 } // namespace Thread
 } // namespace EA
 
-#endif // defined(EA_PLATFORM_WIN32)
+EA_RESTORE_VC_WARNING()
 
+#endif // defined(EA_PLATFORM_WIN32)

--- a/source/pc/eathread_callstack_win64.cpp
+++ b/source/pc/eathread_callstack_win64.cpp
@@ -13,7 +13,7 @@
 	#define _WIN32_WINNT 0x0500
 #endif
 
-#ifdef _MSC_VER
+#ifdef EA_COMPILER_MSVC
 	#pragma warning(push, 0)
 	#include <Windows.h>
 	#include <math.h>       // VS2008 has an acknowledged bug that requires math.h (and possibly also string.h) to be #included before intrin.h.
@@ -38,7 +38,7 @@
 // when compiler optimizations are enabled for this code.
 // This function is not performance-sensitive and so disabling 
 // optimizations shouldn't matter.
-#if defined(_MSC_VER) && (defined(_M_AMD64) || defined(_WIN64))
+#if defined(EA_COMPILER_MSVC) && defined(EA_PLATFORM_WIN64)
 	#pragma optimize("", off) 
 #endif
 
@@ -78,7 +78,7 @@
 
 		PVOID WINAPI RtlLookupFunctionEntry(ULONG64 ControlPC, PULONG64 ImageBase, PUNWIND_HISTORY_TABLE HistoryTable);
 
-		#if !defined(_MSC_VER) || (_MSC_VER < 1500) // if earlier than VS2008...
+		#if !defined(EA_COMPILER_MSVC) || (EA_COMPILER_MSVC < 1500) // if earlier than VS2008...
 			typedef struct _KNONVOLATILE_CONTEXT_POINTERS
 			{ 
 				PULONGLONG dummy; 
@@ -149,7 +149,7 @@ static bool IsAddressReadable(const void* pAddress)
 	//
 	static EA_NO_INLINE void* GetRSP()
 	{
-		#if defined(_MSC_VER)
+		#if defined(EA_COMPILER_MSVC)
 			uintptr_t ara = (uintptr_t)_AddressOfReturnAddress();
 		#else
 			uintptr_t ara = (uintptr_t)__builtin_frame_address();
@@ -164,9 +164,9 @@ static bool IsAddressReadable(const void* pAddress)
 //
 EATHREADLIB_API EA_NO_INLINE void GetInstructionPointer(void*& pInstruction)
 {
-	#if defined(_MSC_VER)
+	#if defined(EA_COMPILER_MSVC)
 		pInstruction = _ReturnAddress();
-	#elif defined(__GNUC__) || defined(EA_COMPILER_CLANG)
+	#elif defined(EA_COMPILER_GNUC) || defined(EA_COMPILER_CLANG)
 		pInstruction = __builtin_return_address(0);
 	#else
 		void* pReturnAddressArray[2] = { 0, 0 };
@@ -613,7 +613,7 @@ EATHREADLIB_API void* GetStackLimit()
 } // namespace EA
 
 
-#if defined(_MSC_VER) && (defined(_M_AMD64) || defined(_WIN64))
+#if defined(EA_COMPILER_MSVC) && defined(EA_PLATFORM_WIN64)
 	#pragma optimize("", on) // See comments above regarding this optimization change.
 #endif
 

--- a/source/pc/eathread_callstack_win64.cpp
+++ b/source/pc/eathread_callstack_win64.cpp
@@ -14,7 +14,7 @@
 #endif
 
 #ifdef EA_COMPILER_MSVC
-	#pragma warning(push, 0)
+	EA_DISABLE_ALL_VC_WARNINGS()
 	#include <Windows.h>
 	#include <math.h>       // VS2008 has an acknowledged bug that requires math.h (and possibly also string.h) to be #included before intrin.h.
 	#include <intrin.h>
@@ -26,7 +26,7 @@
 		extern "C" NTSYSAPI PEXCEPTION_ROUTINE NTAPI RtlVirtualUnwind(DWORD, DWORD64, DWORD64, PRUNTIME_FUNCTION, PCONTEXT, PVOID*, PDWORD64, PKNONVOLATILE_CONTEXT_POINTERS);
 		extern "C" WINBASEAPI DWORD WINAPI GetModuleFileNameA(HMODULE, LPSTR, DWORD);
 	#endif
-	#pragma warning(pop)
+	EA_RESTORE_ALL_VC_WARNINGS()
 #else
 	#include <Windows.h>
 	#include <winternl.h>

--- a/source/pc/eathread_mutex_pc.cpp
+++ b/source/pc/eathread_mutex_pc.cpp
@@ -115,8 +115,7 @@
 
 
 
-	#pragma warning(push)
-	#pragma warning(disable: 4706) // disable warning about assignment within a conditional expression
+	EA_DISABLE_VC_WARNING(4706) // disable warning about assignment within a conditional expression
 
 	int EA::Thread::Mutex::Lock(const ThreadTime& timeoutAbsolute)
 	{
@@ -162,7 +161,7 @@
 		return ++mMutexData.mnLockCount; // This is safe to do because we have the lock.
 	}
 
-	#pragma warning(pop)
+	EA_RESTORE_VC_WARNING()
 
 
 

--- a/source/pc/eathread_pc.cpp
+++ b/source/pc/eathread_pc.cpp
@@ -504,7 +504,7 @@ void* EA::Thread::GetThreadStackBase()
 }
 
 
-#if defined(EA_PLATFORM_WIN32) && defined(EA_PROCESSOR_X86) && defined(_MSC_VER) && (_MSC_VER >= 1400)
+#if defined(EA_PLATFORM_WIN32) && defined(EA_PROCESSOR_X86) && defined(EA_COMPILER_MSVC) && (EA_COMPILER_VERSION >= 1400)
 	// People report on the Internet that this function can get you what CPU the current thread
 	// is running on. But that's false, as this function has been seen to return values greater than
 	// the number of physical or real CPUs present. For example, this function returns 6 for my 
@@ -547,7 +547,7 @@ EATHREADLIB_API int EA::Thread::GetThreadProcessor()
 		if(pfnGetCurrentProcessorNumber)
 			return (int)(unsigned)pfnGetCurrentProcessorNumber();
 
-		#if defined(EA_PLATFORM_WINDOWS) && defined(EA_PROCESSOR_X86) && defined(_MSC_VER) && (_MSC_VER >= 1400)
+		#if defined(EA_PLATFORM_WINDOWS) && defined(EA_PROCESSOR_X86) && defined(EA_COMPILER_MSVC) && (EA_COMPILER_MSVC >= 1400)
 			return GetCurrentProcessorNumberXP();
 		#else
 			return 0;
@@ -693,7 +693,7 @@ namespace Internal {
 		strncpy(pTDD->mName, pName, EATHREAD_NAME_SIZE);
 		pTDD->mName[EATHREAD_NAME_SIZE - 1] = 0;
 
-	#if defined(EA_PLATFORM_WINDOWS) && defined(_MSC_VER) || (defined(EA_PLATFORM_XBOXONE))
+	#if defined(EA_PLATFORM_WINDOWS) && defined(EA_COMPILER_MSVC) || (defined(EA_PLATFORM_XBOXONE))
 		if(pTDD->mName[0] && (pTDD->mhThread != EA::Thread::kThreadIdInvalid))
 		{
 			#if EATHREAD_NAMING == EATHREAD_NAMING_DISABLED
@@ -868,7 +868,7 @@ EATHREADLIB_API void EA::Thread::AssertionFailure(const char* pExpression)
 			OutputDebugStringA("EA::Thread::AssertionFailure: ");
 			OutputDebugStringA(pExpression);
 			OutputDebugStringA("\n");
-			#ifdef _MSC_VER
+			#ifdef EA_COMPILER_MSVC
 				__debugbreak();
 			#endif
 		#endif

--- a/source/pc/eathread_pc.cpp
+++ b/source/pc/eathread_pc.cpp
@@ -676,8 +676,7 @@ namespace Internal {
 
 		jmp_buf jmpbuf;
 
-		__pragma(warning(push))
-		__pragma(warning(disable : 4611))
+		EA_DISABLE_VC_WARNING(4611)
 		if (!setjmp(jmpbuf))
 		{
 			ThreadNameInfo threadNameInfo = {0x1000, pName, threadId, 0};
@@ -685,7 +684,7 @@ namespace Internal {
 			__except (GetExceptionCode() == 0x406D1388 ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH) { }
 			longjmp(jmpbuf, 1);
 		}
-		__pragma(warning(pop))
+		EA_RESTORE_VC_WARNING()
 	}
 
 	void SetThreadName(EAThreadDynamicData* pTDD, const char* pName)

--- a/source/pc/eathread_thread_pc.cpp
+++ b/source/pc/eathread_thread_pc.cpp
@@ -30,7 +30,7 @@ EA_DISABLE_VC_WARNING(6312 6322)
 		#include <Windows.h>
 		EA_RESTORE_ALL_VC_WARNINGS()
 
-		#if defined(_MSC_VER)
+		#if defined(EA_COMPILER_MSVC)
 			struct ThreadNameInfo{
 				DWORD  dwType;
 				LPCSTR lpName;
@@ -42,7 +42,7 @@ EA_DISABLE_VC_WARNING(6312 6322)
 		#endif
 
 
-	#ifdef _MSC_VER
+	#ifdef EA_COMPILER_MSVC
 		#ifndef EATHREAD_INIT_SEG_DEFINED
 			#define EATHREAD_INIT_SEG_DEFINED 
 		#endif

--- a/source/unix/eathread_barrier_unix.cpp
+++ b/source/unix/eathread_barrier_unix.cpp
@@ -15,9 +15,9 @@
 	#include <string.h>
 	#include <new>
 	#ifdef EA_PLATFORM_WINDOWS
-		#pragma warning(push, 0)
+		EA_DISABLE_ALL_VC_WARNINGS()
 		#include <Windows.h> // Presumably we are using pthreads-win32.
-		#pragma warning(pop)
+		EA_RESTORE_ALL_VC_WARNINGS()
 	#endif
 
 

--- a/source/unix/eathread_callstack_glibc.cpp
+++ b/source/unix/eathread_callstack_glibc.cpp
@@ -73,7 +73,7 @@ EATHREADLIB_API size_t GetCallstack(void* pReturnAddressArray[], size_t nReturnA
 		
 		return count;
 
-	#elif defined(__APPLE__) && defined(EA_PROCESSOR_X86)
+	#elif defined(EA_PLATFORM_APPLE) && defined(EA_PROCESSOR_X86)
 		// Apple's ABI defines a callstack frame system.
 		// http://developer.apple.com/library/mac/#documentation/DeveloperTools/Conceptual/LowLevelABI/100-32-bit_PowerPC_Function_Calling_Conventions/32bitPowerPC.html#//apple_ref/doc/uid/TP40002438-SW20
 		// Apple x86 stack frame:

--- a/source/unix/eathread_condition_unix.cpp
+++ b/source/unix/eathread_condition_unix.cpp
@@ -14,9 +14,9 @@
 	#include <errno.h>
 	#include <string.h>
 	#ifdef EA_PLATFORM_WINDOWS
-		#pragma warning(push, 0)
+		EA_DISABLE_ALL_VC_WARNINGS()
 		#include <Windows.h> // Presumably we are using pthreads-win32.
-		#pragma warning(pop)
+		EA_RESTORE_ALL_VC_WARNINGS()
 	#endif
 
 

--- a/source/unix/eathread_mutex_unix.cpp
+++ b/source/unix/eathread_mutex_unix.cpp
@@ -142,7 +142,7 @@
 		}
 		else
 		{
-			#if (defined(EA_PLATFORM_LINUX) || defined(EA_PLATFORM_WINDOWS)) && !defined(__CYGWIN__) && !defined(EA_PLATFORM_ANDROID)
+			#if (defined(EA_PLATFORM_LINUX) || defined(EA_PLATFORM_WINDOWS)) && !defined(EA_PLATFORM_CYGWIN) && !defined(EA_PLATFORM_ANDROID)
 				const timespec* pTimeSpec = &timeoutAbsolute;
 				result = pthread_mutex_timedlock(&mMutexData.mMutex, const_cast<timespec*>(pTimeSpec)); // Some pthread implementations use non-const timespec, so cast for them.
 

--- a/source/unix/eathread_mutex_unix.cpp
+++ b/source/unix/eathread_mutex_unix.cpp
@@ -12,9 +12,9 @@
 	#include <errno.h>
 	#include <string.h>
 	#ifdef EA_PLATFORM_WINDOWS
-	  #pragma warning(push, 0)
+	  EA_DISABLE_ALL_VC_WARNINGS()
 	  #include <Windows.h> // Presumably we are using pthreads-win32.
-	  #pragma warning(pop)
+	  EA_RESTORE_ALL_VC_WARNINGS()
 		#ifdef CreateMutex
 			#undef CreateMutex // Windows #defines CreateMutex to CreateMutexA or CreateMutexW.
 		#endif

--- a/source/unix/eathread_semaphore_unix.cpp
+++ b/source/unix/eathread_semaphore_unix.cpp
@@ -14,10 +14,10 @@
 	#include <stdio.h>
 	#include <limits.h>
 	#ifdef EA_PLATFORM_WINDOWS
-		#pragma warning(push, 0)
+		EA_DISABLE_ALL_VC_WARNINGS()
 		#include <pthread.h>
 		#include <Windows.h> // Presumably we are using pthreads-win32.
-		#pragma warning(pop)
+		EA_RESTORE_ALL_VC_WARNINGS()
 		#ifdef CreateSemaphore
 			#undef CreateSemaphore // Windows #defines CreateSemaphore to CreateSemaphoreA or CreateSemaphoreW.
 		#endif

--- a/source/unix/eathread_thread_unix.cpp
+++ b/source/unix/eathread_thread_unix.cpp
@@ -27,10 +27,10 @@
         #include <sys/prctl.h>
         #include <sys/syscall.h>
         #include <unistd.h>
-    #elif defined(EA_PLATFORM_APPLE) || defined(__APPLE__)
+    #elif defined(EA_PLATFORM_APPLE)
 		#include <unistd.h>
         #include <dlfcn.h>
-    #elif defined(EA_PLATFORM_BSD) || defined(EA_PLATFORM_CONSOLE_BSD) || defined(__FreeBSD__)
+    #elif defined(EA_PLATFORM_BSD) || defined(EA_PLATFORM_CONSOLE_BSD) || defined(EA_PLATFORM_FREEBSD)
         #include <pthread_np.h>
     #endif
 
@@ -60,7 +60,7 @@ namespace
         #if defined(EA_PLATFORM_WINDOWS)
             param.sched_priority = THREAD_PRIORITY_NORMAL + (nPriority - kThreadPriorityDefault);
 
-        #elif defined(EA_PLATFORM_LINUX) && !defined(__CYGWIN__)
+        #elif defined(EA_PLATFORM_LINUX) && !defined(EA_PLATFORM_CYGWIN)
             // We are assuming Kernel 2.6 and later behaviour, but perhaps we should dynamically detect.
             // Linux supports three scheduling policies SCHED_OTHER, SCHED_RR, and SCHED_FIFO. 
             // The process needs to be run with superuser privileges to use SCHED_RR or SCHED_FIFO.
@@ -95,7 +95,7 @@ namespace
             #endif
 
         #else
-            #if defined(__CYGWIN__)
+            #if defined(EA_PLATFORM_CYGWIN)
                 policy = SCHED_OTHER;
             #else
                 policy = SCHED_FIFO;
@@ -134,14 +134,14 @@ namespace
     {
         using namespace EA::Thread;
 
-        #if defined(EA_PLATFORM_LINUX) && !defined(__CYGWIN__)
+        #if defined(EA_PLATFORM_LINUX) && !defined(EA_PLATFORM_CYGWIN)
             EA_UNUSED(policy);
             return kThreadPriorityDefault + param.sched_priority; // This works for both SCHED_OTHER, SCHED_RR, and SCHED_FIFO.
         #else
             #if defined(EA_PLATFORM_WINDOWS) // In the case of windows, we know for sure that normal priority is defined by 'THREAD_PRIORITY_NORMAL'.
                 if(param.sched_priority == THREAD_PRIORITY_NORMAL)
                     return kThreadPriorityDefault;
-            #elif !(defined(__CYGWIN__) || defined(CS_UNDEFINED_STRING))
+            #elif !(defined(EA_PLATFORM_CYGWIN) || defined(CS_UNDEFINED_STRING))
                 if(policy == SCHED_OTHER)
                     return 0;   // 0 is the only priority permitted with the SCHED_OTHER scheduling scheme.
             #endif
@@ -177,10 +177,10 @@ namespace
             {
                 EAT_ASSERT(pTP->mnStackSize != 0);
 
-                #if !defined(__CYGWIN__)  // Some implementations of pthreads does not support pthread_attr_setstack.
-					#if defined(PTHREAD_STACK_MIN)
-						EAT_ASSERT((pTP->mnStackSize >= PTHREAD_STACK_MIN));
-					#endif
+                #if !defined(EA_PLATFORM_CYGWIN) // Some implementations of pthreads does not support pthread_attr_setstack.
+                    #if defined(PTHREAD_STACK_MIN)
+                        EAT_ASSERT((pTP->mnStackSize >= PTHREAD_STACK_MIN));
+                    #endif
                     result = pthread_attr_setstack(&creationAttribs, (void*)pTP->mpStack, pTP->mnStackSize);
                     EAT_ASSERT(result == 0);
                 #endif

--- a/source/unix/eathread_unix.cpp
+++ b/source/unix/eathread_unix.cpp
@@ -14,9 +14,9 @@
 	#include <sched.h>
 	#include <string.h>
 	#ifdef EA_PLATFORM_WINDOWS
-		#pragma warning(push, 0)
+		EA_DISABLE_ALL_VC_WARNINGS()
 		#include <Windows.h> // Presumably we are using pthreads-win32.
-		#pragma warning(pop)
+		EA_RESTORE_ALL_VC_WARNINGS()
 		#include <time.h>
 	#else
 		#include <unistd.h>

--- a/source/x86/eathread_callstack_x86.cpp
+++ b/source/x86/eathread_callstack_x86.cpp
@@ -24,10 +24,10 @@
 #endif
 
 #if defined(EA_COMPILER_MSVC) && defined(EA_PROCESSOR_X86_64)
-	#pragma warning(push, 0)
+	EA_DISABLE_ALL_VC_WARNINGS()
 	#include <math.h>   // VS2008 has an acknowledged bug that requires math.h (and possibly also string.h) to be #included before intrin.h.
 	#include <intrin.h>
-	#pragma warning(pop)
+	EA_RESTORE_ALL_VC_WARNINGS()
 #endif
 
 #if defined(EA_COMPILER_CLANG)

--- a/source/x86/eathread_callstack_x86.cpp
+++ b/source/x86/eathread_callstack_x86.cpp
@@ -56,7 +56,7 @@ EATHREADLIB_API void ShutdownCallstack()
 }
 
 
-#if defined(_MSC_VER)
+#if defined(EA_COMPILER_MSVC)
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -237,7 +237,7 @@ EATHREADLIB_API size_t GetCallstack(void* pReturnAddressArray[], size_t nReturnA
 	return index;
 }
 
-#elif defined(__GNUC__) || defined(EA_COMPILER_CLANG)
+#elif defined(EA_COMPILER_GNUC) || defined(EA_COMPILER_CLANG)
 
 EATHREADLIB_API void GetInstructionPointer(void *&p)
 {
@@ -319,14 +319,14 @@ EATHREADLIB_API size_t GetCallstack(void* pReturnAddressArray[], size_t nReturnA
 			void** sp;
 			void** new_sp;
 
-			#if defined(__i386__)
+			#if defined(EA_PROCESSOR_X86)
 				// Stack frame format:
 				//    sp[0]   pointer to previous frame
 				//    sp[1]   caller address
 				//    sp[2]   first argument
 				//    ...
 				sp = (void**)&pReturnAddressArray - 2;
-			#elif defined(__x86_64__)
+			#elif defined(EA_PROCESSOR_X86_64)
 				// Arguments are passed in registers on x86-64, so we can't just offset from &pReturnAddressArray.
 				sp = (void**) __builtin_frame_address(0);
 			#endif

--- a/test/thread/source/TestThreadCallstack.cpp
+++ b/test/thread/source/TestThreadCallstack.cpp
@@ -19,8 +19,9 @@
 
 
 #ifdef EA_PLATFORM_MICROSOFT
-#pragma warning(push, 0)
+EA_DISABLE_ALL_VC_WARNINGS()
 #include <Windows.h>
+EA_RESTORE_ALL_VC_WARNINGS()
 #endif
 
 

--- a/test/thread/source/TestThreadCallstack.cpp
+++ b/test/thread/source/TestThreadCallstack.cpp
@@ -18,7 +18,7 @@
 #include <eathread/eathread_semaphore.h>
 
 
-#ifdef _MSC_VER
+#ifdef EA_PLATFORM_MICROSOFT
 #pragma warning(push, 0)
 #include <Windows.h>
 #endif

--- a/test/thread/source/TestThreadThread.cpp
+++ b/test/thread/source/TestThreadThread.cpp
@@ -865,7 +865,7 @@ int TestThreadThread()
 		// It turns out that you can't really do such a thing as set lower priority with most Unix threading subsystems. 
 		// You can do so with Cygwin because it is just a pthreads API running on Windows OS/threading.
 		// C++11 thread libraries also provide no means to set or query thread priority.
-		#if (!defined(EA_PLATFORM_UNIX) || defined(__CYGWIN__)) && !EA_USE_CPP11_CONCURRENCY
+		#if (!defined(EA_PLATFORM_UNIX) || defined(EA_PLATFORM_CYGWIN)) && !EA_USE_CPP11_CONCURRENCY
 			int  nPriority1;
 			bool bResult;
 


### PR DESCRIPTION
This is a huge one, sorry for that.

These commits get rid of raw platform/process/library/compilers defines, i.e. `_MSC_VER`. And it replaces MSVC warning pragmas with `EA_DISABLE_VC_WARNING` and the likes. 
I think this is more clear, and easier to read/reason about.

I can split the first commit up in smaller, easier digestible commits if needed.