### PR TITLE
MinGW-w64 fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 ctags
 /build/
 build.bat
+
+# vim temporaries
+*.swp
+*.un~
+*.~

--- a/include/eathread/eathread_callstack.h
+++ b/include/eathread/eathread_callstack.h
@@ -323,7 +323,7 @@ namespace EA
 
 		#endif
 
-		#if defined(EA_PLATFORM_UNIX) || defined(EA_PLATFORM_APPLE) || defined(EA_PLATFORM_SONY)
+		#if defined(EA_PLATFORM_UNIX) || defined(EA_PLATFORM_APPLE) || defined(EA_PLATFORM_SONY) || defined(EA_PLATFORM_MINGW)
 			// GetPthreadStackInfo
 			//
 			// With some implementations of pthread, the stack base is returned by pthread as NULL if it's the main thread,

--- a/include/eathread/eathread_futex.h
+++ b/include/eathread/eathread_futex.h
@@ -114,6 +114,18 @@
 					#define _Must_inspect_result_
 				#endif
 
+				#ifndef _Out_
+					#define _Out_
+				#endif
+
+				#ifndef _Inout_
+					#define _Inout_
+				#endif
+
+				#ifndef _In_
+					#define _In_
+				#endif
+
 				struct _RTL_CRITICAL_SECTION;
 				__declspec(dllimport) _Must_inspect_result_ int           __stdcall InitializeCriticalSectionAndSpinCount(_Out_ _RTL_CRITICAL_SECTION* pCriticalSection, _In_ unsigned long dwSpinCount);
 				__declspec(dllimport) void          __stdcall InitializeCriticalSection(_Out_ _RTL_CRITICAL_SECTION* pCriticalSection);

--- a/include/eathread/internal/config.h
+++ b/include/eathread/internal/config.h
@@ -114,7 +114,7 @@ EA_RESTORE_VC_WARNING()
 // Defined as 0 or 1
 //
 #ifndef EA_POSIX_THREADS_AVAILABLE
-	#if defined(EA_PLATFORM_UNIX) || defined(EA_PLATFORM_LINUX) || defined(EA_PLATFORM_APPLE)
+	#if defined(EA_PLATFORM_UNIX) || defined(EA_PLATFORM_LINUX) || defined(EA_PLATFORM_APPLE) || defined(EA_PLATFORM_MINGW)
 		#define EA_POSIX_THREADS_AVAILABLE 1
 	#elif defined(EA_PLATFORM_SONY)
 	   #define EA_POSIX_THREADS_AVAILABLE 0  // POSIX threading API is present but use is discouraged by Sony.  They want shipping code to use their scePthreads* API.
@@ -484,9 +484,9 @@ EA_RESTORE_VC_WARNING()
 		#define EATHREAD_GETCALLSTACK_SUPPORTED 1
 	#elif defined(EA_PLATFORM_WINDOWS_PHONE) && defined(EA_PROCESSOR_ARM)       
 		#define EATHREAD_GETCALLSTACK_SUPPORTED 0
-	#elif defined(EA_PLATFORM_MICROSOFT)
+	#elif defined(EA_PLATFORM_MICROSOFT) && !defined(EA_PLATFORM_MINGW)
 		#define EATHREAD_GETCALLSTACK_SUPPORTED 1
-	#elif defined(EA_PLATFORM_LINUX)
+	#elif defined(EA_PLATFORM_LINUX) && !defined(EA_PLATFORM_CYGWIN)
 		#define EATHREAD_GETCALLSTACK_SUPPORTED 1
 	#elif defined(EA_PLATFORM_OSX)
 		#define EATHREAD_GETCALLSTACK_SUPPORTED 1
@@ -537,7 +537,7 @@ EA_RESTORE_VC_WARNING()
 	#elif defined(EA_PLATFORM_SONY)
 		#define EATHREAD_THREAD_AFFINITY_MASK_SUPPORTED 1
 	#elif defined(EA_USE_CPP11_CONCURRENCY) && EA_USE_CPP11_CONCURRENCY
-		// CPP11 doesn't not provided a mechanism to set thread affinities.
+		// CPP11 doesn't provide a mechanism to set thread affinities.
 		#define EATHREAD_THREAD_AFFINITY_MASK_SUPPORTED 0
 	#elif defined(EA_PLATFORM_ANDROID) || defined(EA_PLATFORM_APPLE) || defined(EA_PLATFORM_UNIX)
 		#define EATHREAD_THREAD_AFFINITY_MASK_SUPPORTED 0

--- a/source/eathread_callstack.cpp
+++ b/source/eathread_callstack.cpp
@@ -4,9 +4,9 @@
 
 #include <EABase/eabase.h>
 
-#if defined(EA_PLATFORM_WIN32) && EA_WINAPI_FAMILY_PARTITION(EA_WINAPI_PARTITION_DESKTOP)
+#if defined(EA_PLATFORM_WIN32) && EA_WINAPI_FAMILY_PARTITION(EA_WINAPI_PARTITION_DESKTOP) && !defined(EA_PLATFORM_MINGW)
 	#include "pc/eathread_callstack_win32.cpp"
-#elif defined(EA_PLATFORM_MICROSOFT) && defined(EA_PROCESSOR_X86_64)
+#elif defined(EA_PLATFORM_MICROSOFT) && defined(EA_PROCESSOR_X86_64) && !defined(EA_PLATFORM_MINGW)
 	#include "pc/eathread_callstack_win64.cpp"
 #elif defined(EA_PLATFORM_SONY)
 	#include "kettle/eathread_callstack_kettle.cpp"

--- a/source/pc/eathread_thread_pc.cpp
+++ b/source/pc/eathread_thread_pc.cpp
@@ -85,7 +85,7 @@ EA_DISABLE_VC_WARNING(6312 6322)
 
 				EAThreadGlobalVars() {}
 				EAThreadGlobalVars(const EAThreadGlobalVars&) {}
-				EAThreadGlobalVars& operator=(const EAThreadGlobalVars&) {}
+				EAThreadGlobalVars& operator=(const EAThreadGlobalVars&) { return *this; }
 			};
 			EATHREAD_GLOBALVARS_CREATE_INSTANCE;
 

--- a/source/unix/eathread_callstack_glibc.cpp
+++ b/source/unix/eathread_callstack_glibc.cpp
@@ -228,7 +228,7 @@ EATHREADLIB_API void SetStackBase(void* pStackBase)
 //
 EATHREADLIB_API void* GetStackBase()
 {
-	#if defined(EA_PLATFORM_UNIX)
+	#if defined(EA_PLATFORM_UNIX) || defined(EA_PLATFORM_MINGW)
 		void* pBase;
 		if(GetPthreadStackInfo(&pBase, NULL))
 			return pBase;
@@ -246,7 +246,7 @@ EATHREADLIB_API void* GetStackBase()
 //
 EATHREADLIB_API void* GetStackLimit()
 {
-	#if defined(EA_PLATFORM_UNIX)
+	#if defined(EA_PLATFORM_UNIX) || defined(EA_PLATFORM_MINGW)
 		void* pLimit;
 		if(GetPthreadStackInfo(NULL, &pLimit))
 			return pLimit;

--- a/test/thread/source/TestThreadCallstack.cpp
+++ b/test/thread/source/TestThreadCallstack.cpp
@@ -257,7 +257,7 @@ EA_NO_INLINE EACALLSTACK_TEST_FUNCTION_LINKAGE  int TestRemoteThreadContextVsCal
 	auto threadId = remoteThread.mThread.GetId();
 
 	{
-#if defined(EA_PLATFORM_WINDOWS) || defined(EA_PLATFORM_XBOXONE)
+#if (defined(EA_PLATFORM_WINDOWS) || defined(EA_PLATFORM_XBOXONE)) && !defined(EA_PLATFORM_MINGW)
 		// suspend the target thread to make sure we get a coherent callstack
 		bool wasSuspended = (::SuspendThread(threadId) != ((DWORD)-1)); // fail is (DWORD)-1
 #endif
@@ -268,7 +268,7 @@ EA_NO_INLINE EACALLSTACK_TEST_FUNCTION_LINKAGE  int TestRemoteThreadContextVsCal
 			EA::Thread::GetCallstack(addressContextArray, EAArrayCount(addressContextArray), &callstackContext);
 		}
 
-#if defined(EA_PLATFORM_WINDOWS) || defined(EA_PLATFORM_XBOXONE)
+#if (defined(EA_PLATFORM_WINDOWS) || defined(EA_PLATFORM_XBOXONE)) && !defined(EA_PLATFORM_MINGW)
 		// resume the target thread as needed
 		if (wasSuspended)
 		{

--- a/test/thread/source/TestThreadThread.cpp
+++ b/test/thread/source/TestThreadThread.cpp
@@ -899,7 +899,8 @@ int TestThreadThread()
 
 
 	#if defined(EA_PLATFORM_WINDOWS) && !EA_USE_CPP11_CONCURRENCY
-	{ // Try to reproduce Windows problem with Thread::GetStatus returning kStatusEnded when it should return kStatusRunning.
+	{
+		// Try to reproduce Windows problem with Thread::GetStatus returning kStatusEnded when it should return kStatusRunning.
 		// On my current work machine (WinXP32, Single P4 CPU) this problem doesn't occur. But it might occur with others.
 		Thread::Status status;
 		Thread         threadBackground[8];
@@ -910,6 +911,7 @@ int TestThreadThread()
 
 		EA::Thread::SetThreadPriority(kThreadPriorityDefault + 2);
 		thread.Begin(TestFunction1);
+		ThreadSleep(10); // It's possible the thread hasn't started yet, so wait to make sure it has.
 		status = thread.GetStatus();
 		EA::Thread::SetThreadPriority(kThreadPriorityDefault);
 


### PR DESCRIPTION
In this PR I made MinGW-w64 compilers work again with EAThread.  
I opted for using pthreads, as those are native to MinGW-w64 and GCC has no support for SEH intrinsics, such as `__try` and `__catch`.

I tested this with GCC, Clang, MSVC, and Clang-CL, but I can't remember if I tested it on Linux.

If possible I'd like to extend EAThread to be numa-aware somewhere in the future, so that MinGW users can make use of all threads on new high core count CPUs. I'm assuming the MSVC side is already numa aware.

As usual, let me know if there are any issues with the PR :)