### PR TITLE
Fix CMake build on Ubuntu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 # Export Include Directories
 #-------------------------------------------------------------------------------------------
 target_include_directories(EAThread PUBLIC include)
-
+target_include_directories(EAThread PRIVATE ../EABase/include/Common)
 #-------------------------------------------------------------------------------------------
 # Package Dependencies 
 #-------------------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,6 @@ add_library(EAThread ${EATHREAD_SOURCES})
 
 if(EATHREAD_BUILD_TESTS)
     add_subdirectory(test)
-else()
-    add_subdirectory(test/packages/EABase)
 endif()
 
 #-------------------------------------------------------------------------------------------
@@ -38,8 +36,4 @@ add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 #-------------------------------------------------------------------------------------------
 target_include_directories(EAThread PUBLIC include)
 target_include_directories(EAThread PRIVATE ../EABase/include/Common)
-#-------------------------------------------------------------------------------------------
-# Package Dependencies 
-#-------------------------------------------------------------------------------------------
-target_link_libraries(EAThread EABase)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,7 +51,7 @@ add_subdirectory(packages/EAStdC)
 add_subdirectory(packages/EATest)
 
 target_link_libraries(EAThreadTest EAAssert)
-target_link_libraries(EAThreadTest EABase)
+)
 target_link_libraries(EAThreadTest EAMain)
 target_link_libraries(EAThreadTest EASTL)
 target_link_libraries(EAThreadTest EAStdC)


### PR DESCRIPTION
Change EABase from link to include - the libraries won't build otherwise on Ubuntu.
I'm guessing that in the past EABase was a binary library to link against, and was changed to header only - but I didn't chase its history.