### PR TITLE
Allow manual EABase cmake installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,9 @@ add_library(EAThread ${EATHREAD_SOURCES})
 if(EATHREAD_BUILD_TESTS)
     add_subdirectory(test)
 else()
-    add_subdirectory(test/packages/EABase)
+    if (NOT TARGET EABase)
+        add_subdirectory(test/packages/EABase)
+    endif()
 endif()
 
 #-------------------------------------------------------------------------------------------


### PR DESCRIPTION
Only require EABase to be recursively (git submodule) cloned if EABase target isn't already present.

Solved in the same manner as https://github.com/electronicarts/EASTL/blob/master/CMakeLists.txt#L49
